### PR TITLE
ci: GitHub Actions CI とリリースワークフローを追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test ./...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+          - os: macos-13
+            goos: darwin
+            goarch: amd64
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        env:
+          CGO_ENABLED: 1
+        run: |
+          BINARY_NAME=bqtest-${{ matrix.goos }}-${{ matrix.goarch }}
+          go build -o ${BINARY_NAME} ./cmd/bqtest/
+          tar czf ${BINARY_NAME}.tar.gz ${BINARY_NAME}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bqtest-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: bqtest-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: "*.tar.gz"


### PR DESCRIPTION
## Summary

- CI: push/PR 時に `go test ./...` を実行
- Release: `v*` タグ push 時に以下のバイナリをビルドし GitHub Release に添付
  - `bqtest-linux-amd64`
  - `bqtest-darwin-amd64`
  - `bqtest-darwin-arm64`

CGO 必須 (go-zetasql) のため、各ターゲットはネイティブ runner でビルド。
linux-arm64 は ARM runner が必要なため初期リリースでは除外。

## Test plan

- [ ] PR マージ後に `v0.1.0` タグを push してリリースワークフローの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)