### PR TITLE
docs: READMEにバイナリインストール方法を追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -16,6 +16,22 @@ BigQuery SQL テストランナー。SQL 内のテーブル参照をテスト用
 
 ## インストール
 
+### バイナリダウンロード
+
+```bash
+# macOS (Apple Silicon)
+curl -sL https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-darwin-arm64.tar.gz | tar xz
+mkdir -p ~/.local/bin && mv bqtest-darwin-arm64 ~/.local/bin/bqtest
+
+# Linux (amd64)
+curl -sL https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-linux-amd64.tar.gz | tar xz
+mkdir -p ~/.local/bin && mv bqtest-linux-amd64 ~/.local/bin/bqtest
+```
+
+`~/.local/bin` が `PATH` に含まれていることを確認してください。
+
+### ソースから
+
 ```bash
 go install github.com/matsuri-tech/bqtest/cmd/bqtest@latest
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ BigQuery SQL test runner. Replaces table references in SQL with test fixtures, e
 
 ## Installation
 
+### Download binary
+
+```bash
+# macOS (Apple Silicon)
+curl -sL https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-darwin-arm64.tar.gz | tar xz
+mkdir -p ~/.local/bin && mv bqtest-darwin-arm64 ~/.local/bin/bqtest
+
+# Linux (amd64)
+curl -sL https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-linux-amd64.tar.gz | tar xz
+mkdir -p ~/.local/bin && mv bqtest-linux-amd64 ~/.local/bin/bqtest
+```
+
+Make sure `~/.local/bin` is in your `PATH`.
+
+### From source
+
 ```bash
 go install github.com/matsuri-tech/bqtest/cmd/bqtest@latest
 ```


### PR DESCRIPTION
## Summary

- curl でバイナリをダウンロードするインストール手順を README / README.ja.md に追加
- macOS (Apple Silicon) と Linux (amd64) の例を記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)