### PR TITLE
refactor(release): tar.gz廃止、バイナリ直接配布に変更

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,15 +38,12 @@ jobs:
           CGO_ENABLED: 1
           CC: clang
           CXX: clang++
-        run: |
-          BINARY_NAME=bqtest-${{ matrix.goos }}-${{ matrix.goarch }}
-          go build -o ${BINARY_NAME} ./cmd/bqtest/
-          tar czf ${BINARY_NAME}.tar.gz ${BINARY_NAME}
+        run: go build -o bqtest-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/bqtest/
 
       - uses: actions/upload-artifact@v4
         with:
           name: bqtest-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: bqtest-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+          path: bqtest-${{ matrix.goos }}-${{ matrix.goarch }}
 
   release:
     needs: build
@@ -60,4 +57,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: "*.tar.gz"
+          files: bqtest-*

--- a/README.ja.md
+++ b/README.ja.md
@@ -19,13 +19,15 @@ BigQuery SQL テストランナー。SQL 内のテーブル参照をテスト用
 ### バイナリダウンロード
 
 ```bash
+mkdir -p ~/.local/bin
+
 # macOS (Apple Silicon)
-curl -sL https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-darwin-arm64.tar.gz | tar xz
-mkdir -p ~/.local/bin && mv bqtest-darwin-arm64 ~/.local/bin/bqtest
+curl -sL -o ~/.local/bin/bqtest https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-darwin-arm64
+chmod +x ~/.local/bin/bqtest
 
 # Linux (amd64)
-curl -sL https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-linux-amd64.tar.gz | tar xz
-mkdir -p ~/.local/bin && mv bqtest-linux-amd64 ~/.local/bin/bqtest
+curl -sL -o ~/.local/bin/bqtest https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-linux-amd64
+chmod +x ~/.local/bin/bqtest
 ```
 
 `~/.local/bin` が `PATH` に含まれていることを確認してください。

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ BigQuery SQL test runner. Replaces table references in SQL with test fixtures, e
 ### Download binary
 
 ```bash
+mkdir -p ~/.local/bin
+
 # macOS (Apple Silicon)
-curl -sL https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-darwin-arm64.tar.gz | tar xz
-mkdir -p ~/.local/bin && mv bqtest-darwin-arm64 ~/.local/bin/bqtest
+curl -sL -o ~/.local/bin/bqtest https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-darwin-arm64
+chmod +x ~/.local/bin/bqtest
 
 # Linux (amd64)
-curl -sL https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-linux-amd64.tar.gz | tar xz
-mkdir -p ~/.local/bin && mv bqtest-linux-amd64 ~/.local/bin/bqtest
+curl -sL -o ~/.local/bin/bqtest https://github.com/matsuri-tech/bqtest/releases/latest/download/bqtest-linux-amd64
+chmod +x ~/.local/bin/bqtest
 ```
 
 Make sure `~/.local/bin` is in your `PATH`.


### PR DESCRIPTION
## Summary

- リリース成果物を tar.gz からバイナリ直接配布に変更
- README のインストール手順を `curl -o` に簡素化

🤖 Generated with [Claude Code](https://claude.com/claude-code)