### PR TITLE
fix(ci): ビルドキャッシュ有効化 + macOS ad-hoc署名

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
       - name: Install clang
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Install clang (Linux)
         if: runner.os == 'Linux'
@@ -39,6 +40,10 @@ jobs:
           CC: clang
           CXX: clang++
         run: go build -o bqtest-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/bqtest/
+
+      - name: Ad-hoc codesign (macOS)
+        if: runner.os == 'macOS'
+        run: codesign --force --sign - bqtest-${{ matrix.goos }}-${{ matrix.goarch }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- `actions/setup-go` に `cache: true` を追加し Go ビルドキャッシュを有効化（CGO の C++ コンパイル結果がキャッシュされ、2回目以降のビルドが大幅に高速化）
- macOS バイナリに `codesign --force --sign -` で ad-hoc 署名を追加（ダウンロード後に Gatekeeper で SIGKILL される問題を修正）

## Test plan

- [ ] PR の CI でキャッシュが作成されることを確認
- [ ] マージ後に v0.2.1 をリリースし、キャッシュ有効時のビルド時間を比較
- [ ] macOS バイナリが curl ダウンロード後にそのまま実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)