### PR TITLE
fix(cli): .bigqueryrcのlocation設定案内を修正

### DIFF
--- a/cmd/bqtest/main.go
+++ b/cmd/bqtest/main.go
@@ -131,7 +131,7 @@ func executeRun(args []string) error {
 		location = detectDefaultLocation()
 	}
 	if location == "" {
-		fmt.Fprintln(os.Stderr, "Error: BigQuery location is required.\n\nSpecify it with one of:\n  --location <location>\n  BQTEST_LOCATION=<location>\n  Add '--location=<location>' to ~/.bigqueryrc")
+		fmt.Fprintln(os.Stderr, "Error: BigQuery location is required.\n\nSpecify it with one of:\n  --location <location>\n  BQTEST_LOCATION=<location>\n  Add 'location = <location>' to ~/.bigqueryrc")
 		os.Exit(exitFail)
 	}
 


### PR DESCRIPTION
## Summary

エラーメッセージ内の `.bigqueryrc` 設定例を `--location=` 形式から実際の `location = ` 形式に修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)