### PR TITLE
fix(rewriter): 2-partテーブル参照を3-part fixture定義にマッチさせる

### DIFF
--- a/rewriter/rewriter.go
+++ b/rewriter/rewriter.go
@@ -35,6 +35,9 @@ func Rewrite(sql string, rewriteMap map[string]string, passthrough map[string]bo
 		RewrittenTables: make(map[string]string),
 	}
 
+	// Collect project prefixes from 3-part keys in rewriteMap for fallback matching
+	projectPrefixes := collectProjectPrefixes(rewriteMap)
+
 	// We need all occurrences (not deduped) to get correct offsets.
 	// Re-extract with offsets by parsing again and collecting all refs.
 	allRefs, err := extractAllRefs(sql)
@@ -47,7 +50,7 @@ func Rewrite(sql string, rewriteMap map[string]string, passthrough map[string]bo
 		if !ref.IsSource {
 			continue
 		}
-		tempName, hasFixture := rewriteMap[ref.Path]
+		tempName, hasFixture := resolveRef(ref.Path, rewriteMap, projectPrefixes)
 		if hasFixture {
 			replacements = append(replacements, replacement{
 				start:   ref.StartOffset,
@@ -105,9 +108,11 @@ func ValidateRewrite(sql string, rewriteMap map[string]string, passthrough map[s
 		return err
 	}
 
+	projectPrefixes := collectProjectPrefixes(rewriteMap)
+
 	var missing []string
 	for _, ref := range parseResult.SourceTables {
-		if _, hasFixture := rewriteMap[ref.Path]; hasFixture {
+		if _, found := resolveRef(ref.Path, rewriteMap, projectPrefixes); found {
 			continue
 		}
 		if passthrough[ref.Path] {
@@ -120,4 +125,41 @@ func ValidateRewrite(sql string, rewriteMap map[string]string, passthrough map[s
 		return fmt.Errorf("source tables without fixtures or passthrough: %s", strings.Join(missing, ", "))
 	}
 	return nil
+}
+
+// collectProjectPrefixes extracts unique project prefixes from 3-part keys in the map.
+func collectProjectPrefixes(rewriteMap map[string]string) []string {
+	seen := make(map[string]bool)
+	for key := range rewriteMap {
+		parts := strings.SplitN(key, ".", 3)
+		if len(parts) == 3 && !seen[parts[0]] {
+			seen[parts[0]] = true
+		}
+	}
+	prefixes := make([]string, 0, len(seen))
+	for p := range seen {
+		prefixes = append(prefixes, p)
+	}
+	sort.Strings(prefixes)
+	return prefixes
+}
+
+// resolveRef looks up a table reference in the rewriteMap.
+// If the ref is 2-part (dataset.table) and not found directly, it tries
+// prepending each known project prefix to form a 3-part key.
+func resolveRef(path string, rewriteMap map[string]string, projectPrefixes []string) (string, bool) {
+	if tempName, ok := rewriteMap[path]; ok {
+		return tempName, true
+	}
+	// Only try fallback for 2-part refs
+	parts := strings.SplitN(path, ".", 3)
+	if len(parts) == 2 {
+		for _, proj := range projectPrefixes {
+			candidate := proj + "." + path
+			if tempName, ok := rewriteMap[candidate]; ok {
+				return tempName, true
+			}
+		}
+	}
+	return "", false
 }

--- a/rewriter/rewriter_test.go
+++ b/rewriter/rewriter_test.go
@@ -94,6 +94,85 @@ func TestRewrite_WithCTE(t *testing.T) {
 	}
 }
 
+func TestRewrite_TwoPartRefMatchesThreePartFixture(t *testing.T) {
+	sql := "SELECT * FROM `dx_018_reservation.reservation_basic` WHERE id = 1"
+	rewriteMap := map[string]string{
+		"m2m-core.dx_018_reservation.reservation_basic": "reservation_basic",
+	}
+	result, err := Rewrite(sql, rewriteMap, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "SELECT * FROM reservation_basic WHERE id = 1"
+	if result.SQL != expected {
+		t.Errorf("expected:\n  %s\ngot:\n  %s", expected, result.SQL)
+	}
+	if result.RewrittenTables["dx_018_reservation.reservation_basic"] != "reservation_basic" {
+		t.Errorf("expected rewrite map entry for 2-part ref, got %v", result.RewrittenTables)
+	}
+	if len(result.UnresolvedTables) != 0 {
+		t.Errorf("expected no unresolved tables, got %v", result.UnresolvedTables)
+	}
+}
+
+func TestRewrite_TwoPartRefWithMultipleProjects(t *testing.T) {
+	sql := "SELECT * FROM `dataset.orders` o JOIN `dataset.users` u ON o.user_id = u.id"
+	rewriteMap := map[string]string{
+		"projA.dataset.orders": "orders",
+		"projB.dataset.users":  "users",
+	}
+	result, err := Rewrite(sql, rewriteMap, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.SQL, "FROM orders o") {
+		t.Errorf("expected orders replacement, got: %s", result.SQL)
+	}
+	if !strings.Contains(result.SQL, "JOIN users u") {
+		t.Errorf("expected users replacement, got: %s", result.SQL)
+	}
+}
+
+func TestRewrite_ThreePartRefStillWorks(t *testing.T) {
+	// Ensure 3-part refs still work as before (no regression)
+	sql := "SELECT * FROM `myproj.dataset.orders` WHERE amount > 100"
+	rewriteMap := map[string]string{
+		"myproj.dataset.orders": "orders",
+	}
+	result, err := Rewrite(sql, rewriteMap, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "SELECT * FROM orders WHERE amount > 100"
+	if result.SQL != expected {
+		t.Errorf("expected:\n  %s\ngot:\n  %s", expected, result.SQL)
+	}
+}
+
+func TestRewrite_TwoPartRefUnresolvedWhenNoProjectMatch(t *testing.T) {
+	sql := "SELECT * FROM `dataset.unknown_table`"
+	rewriteMap := map[string]string{
+		"myproj.dataset.orders": "orders",
+	}
+	result, err := Rewrite(sql, rewriteMap, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.UnresolvedTables) != 1 || result.UnresolvedTables[0] != "dataset.unknown_table" {
+		t.Errorf("expected unresolved dataset.unknown_table, got %v", result.UnresolvedTables)
+	}
+}
+
+func TestValidateRewrite_TwoPartRefMatchesThreePartFixture(t *testing.T) {
+	sql := "SELECT * FROM `dx_018_reservation.reservation_basic`"
+	rewriteMap := map[string]string{
+		"m2m-core.dx_018_reservation.reservation_basic": "reservation_basic",
+	}
+	if err := ValidateRewrite(sql, rewriteMap, nil); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestValidateRewrite_Success(t *testing.T) {
 	sql := "SELECT * FROM `myproj.dataset.orders`"
 	rewriteMap := map[string]string{


### PR DESCRIPTION
## Summary
- SQLで `dataset.table` (2-part) 形式のテーブル参照を使用し、fixtureが `project.dataset.table` (3-part) で定義されている場合にマッチしない問題を修正
- rewriteMapの3-partキーからプロジェクトプレフィックスを収集し、2-part参照にプレフィックスを付与してフォールバックマッチを試みる `resolveRef` / `collectProjectPrefixes` ヘルパーを追加
- `Rewrite` と `ValidateRewrite` の両方で2-part → 3-partのフォールバック解決を適用

Closes #14

## Test plan
- [x] 2-part参照が3-part fixtureにマッチするテスト (`TestRewrite_TwoPartRefMatchesThreePartFixture`)
- [x] 複数プロジェクトの2-part参照テスト (`TestRewrite_TwoPartRefWithMultipleProjects`)
- [x] 3-part参照の既存動作が壊れないリグレッションテスト (`TestRewrite_ThreePartRefStillWorks`)
- [x] マッチしない2-part参照がunresolvedになるテスト (`TestRewrite_TwoPartRefUnresolvedWhenNoProjectMatch`)
- [x] ValidateRewriteでの2-part→3-partマッチテスト (`TestValidateRewrite_TwoPartRefMatchesThreePartFixture`)
- [x] `go test ./...` 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)