### PR TITLE
fix: temp table名をバッククォートで囲み予約語の衝突を回避

### DIFF
--- a/rewriter/rewriter.go
+++ b/rewriter/rewriter.go
@@ -55,7 +55,7 @@ func Rewrite(sql string, rewriteMap map[string]string, passthrough map[string]bo
 			replacements = append(replacements, replacement{
 				start:   ref.StartOffset,
 				end:     ref.EndOffset,
-				newText: tempName,
+				newText: "`" + tempName + "`",
 			})
 			result.RewrittenTables[ref.Path] = tempName
 		} else if !passthrough[ref.Path] && !seen[ref.Path] {

--- a/rewriter/rewriter_test.go
+++ b/rewriter/rewriter_test.go
@@ -14,7 +14,7 @@ func TestRewrite_SimpleSelect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := "SELECT * FROM orders WHERE amount > 100"
+	expected := "SELECT * FROM `orders` WHERE amount > 100"
 	if result.SQL != expected {
 		t.Errorf("expected:\n  %s\ngot:\n  %s", expected, result.SQL)
 	}
@@ -33,10 +33,10 @@ func TestRewrite_MultipleTableJoin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(result.SQL, "FROM orders o") {
+	if !strings.Contains(result.SQL, "FROM `orders` o") {
 		t.Errorf("expected orders replacement, got: %s", result.SQL)
 	}
-	if !strings.Contains(result.SQL, "JOIN users u") {
+	if !strings.Contains(result.SQL, "JOIN `users` u") {
 		t.Errorf("expected users replacement, got: %s", result.SQL)
 	}
 }
@@ -53,7 +53,7 @@ func TestRewrite_PartialRewrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(result.SQL, "FROM orders o") {
+	if !strings.Contains(result.SQL, "FROM `orders` o") {
 		t.Errorf("expected orders replacement, got: %s", result.SQL)
 	}
 	// users should remain unchanged
@@ -85,7 +85,7 @@ func TestRewrite_WithCTE(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(result.SQL, "FROM orders") {
+	if !strings.Contains(result.SQL, "FROM `orders`") {
 		t.Errorf("expected orders replacement, got: %s", result.SQL)
 	}
 	// CTE reference should remain
@@ -103,7 +103,7 @@ func TestRewrite_TwoPartRefMatchesThreePartFixture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := "SELECT * FROM reservation_basic WHERE id = 1"
+	expected := "SELECT * FROM `reservation_basic` WHERE id = 1"
 	if result.SQL != expected {
 		t.Errorf("expected:\n  %s\ngot:\n  %s", expected, result.SQL)
 	}
@@ -125,10 +125,10 @@ func TestRewrite_TwoPartRefWithMultipleProjects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(result.SQL, "FROM orders o") {
+	if !strings.Contains(result.SQL, "FROM `orders` o") {
 		t.Errorf("expected orders replacement, got: %s", result.SQL)
 	}
-	if !strings.Contains(result.SQL, "JOIN users u") {
+	if !strings.Contains(result.SQL, "JOIN `users` u") {
 		t.Errorf("expected users replacement, got: %s", result.SQL)
 	}
 }
@@ -143,7 +143,7 @@ func TestRewrite_ThreePartRefStillWorks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := "SELECT * FROM orders WHERE amount > 100"
+	expected := "SELECT * FROM `orders` WHERE amount > 100"
 	if result.SQL != expected {
 		t.Errorf("expected:\n  %s\ngot:\n  %s", expected, result.SQL)
 	}
@@ -160,6 +160,22 @@ func TestRewrite_TwoPartRefUnresolvedWhenNoProjectMatch(t *testing.T) {
 	}
 	if len(result.UnresolvedTables) != 1 || result.UnresolvedTables[0] != "dataset.unknown_table" {
 		t.Errorf("expected unresolved dataset.unknown_table, got %v", result.UnresolvedTables)
+	}
+}
+
+func TestRewrite_ReservedWordTableName(t *testing.T) {
+	sql := "SELECT * FROM `m2m-core.rm_hozin_case.case` WHERE id = 1"
+	rewriteMap := map[string]string{
+		"m2m-core.rm_hozin_case.case": "case",
+	}
+	result, err := Rewrite(sql, rewriteMap, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// "case" is a reserved word; temp name must be backtick-quoted
+	expected := "SELECT * FROM `case` WHERE id = 1"
+	if result.SQL != expected {
+		t.Errorf("expected:\n  %s\ngot:\n  %s", expected, result.SQL)
 	}
 }
 

--- a/script/script.go
+++ b/script/script.go
@@ -45,9 +45,9 @@ func Generate(tc *testcase.TestCase, rewrittenSQL string) string {
 
 func generateFixtureSQL(tempName string, f testcase.Fixture) string {
 	if f.SQL != "" {
-		return fmt.Sprintf("CREATE TEMP TABLE %s AS\n%s;", tempName, f.SQL)
+		return fmt.Sprintf("CREATE TEMP TABLE `%s` AS\n%s;", tempName, f.SQL)
 	}
-	return fmt.Sprintf("CREATE TEMP TABLE %s AS\nSELECT * FROM UNNEST([%s]);", tempName, generateStructArray(f.Rows))
+	return fmt.Sprintf("CREATE TEMP TABLE `%s` AS\nSELECT * FROM UNNEST([%s]);", tempName, generateStructArray(f.Rows))
 }
 
 // generateStructArray builds a comma-separated list of STRUCT literals from rows.

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -31,8 +31,8 @@ func TestGenerate_Basic(t *testing.T) {
 
 	result := Generate(tc, "SELECT * FROM orders")
 
-	// Should contain fixture TEMP TABLE with UNNEST
-	if !strings.Contains(result, "CREATE TEMP TABLE orders AS") {
+	// Should contain fixture TEMP TABLE with UNNEST (backtick-quoted)
+	if !strings.Contains(result, "CREATE TEMP TABLE `orders` AS") {
 		t.Errorf("expected fixture temp table, got:\n%s", result)
 	}
 	if !strings.Contains(result, "STRUCT(") {
@@ -70,7 +70,7 @@ func TestGenerate_SQLFixture(t *testing.T) {
 
 	result := Generate(tc, "SELECT * FROM orders")
 
-	if !strings.Contains(result, "CREATE TEMP TABLE orders AS\nSELECT 1 AS order_id, 100 AS amount;") {
+	if !strings.Contains(result, "CREATE TEMP TABLE `orders` AS\nSELECT 1 AS order_id, 100 AS amount;") {
 		t.Errorf("expected SQL fixture, got:\n%s", result)
 	}
 }
@@ -97,14 +97,14 @@ func TestGenerate_CollisionUsesRewriteMap(t *testing.T) {
 	result := Generate(tc, "SELECT * FROM sumyca_prod__reservation")
 
 	// Should use disambiguated names from RewriteMap, not just "reservation"
-	if !strings.Contains(result, "CREATE TEMP TABLE sumyca_prod__reservation AS") {
+	if !strings.Contains(result, "CREATE TEMP TABLE `sumyca_prod__reservation` AS") {
 		t.Errorf("expected disambiguated temp name sumyca_prod__reservation, got:\n%s", result)
 	}
-	if !strings.Contains(result, "CREATE TEMP TABLE m2m_core_prod__reservation AS") {
+	if !strings.Contains(result, "CREATE TEMP TABLE `m2m_core_prod__reservation` AS") {
 		t.Errorf("expected disambiguated temp name m2m_core_prod__reservation, got:\n%s", result)
 	}
 	// Should NOT have a bare "CREATE TEMP TABLE reservation AS"
-	if strings.Contains(result, "CREATE TEMP TABLE reservation AS") {
+	if strings.Contains(result, "CREATE TEMP TABLE `reservation` AS") {
 		t.Errorf("should not have bare 'reservation' temp table, got:\n%s", result)
 	}
 }
@@ -134,6 +134,38 @@ func TestGenerate_DedupFixtures(t *testing.T) {
 	count := strings.Count(result, "CREATE TEMP TABLE")
 	if count != 1 {
 		t.Errorf("expected 1 CREATE TEMP TABLE (dedup), got %d:\n%s", count, result)
+	}
+}
+
+func TestGenerate_ReservedWordTableName(t *testing.T) {
+	tc := &testcase.TestCase{
+		TestName: "reserved_word",
+		SQL:      "SELECT * FROM `case`",
+		Fixtures: []testcase.Fixture{
+			{
+				Table:    "m2m-core.rm_hozin_case.case",
+				TempName: "case",
+				Rows: []map[string]any{
+					{"id": 1, "name": "test"},
+				},
+			},
+		},
+		Expected: testcase.Expected{
+			Rows: []map[string]any{
+				{"id": 1, "name": "test"},
+			},
+		},
+	}
+
+	result := Generate(tc, "SELECT * FROM `case`")
+
+	// temp table name must be backtick-quoted to avoid reserved word conflict
+	if !strings.Contains(result, "CREATE TEMP TABLE `case` AS") {
+		t.Errorf("expected backtick-quoted temp table for reserved word, got:\n%s", result)
+	}
+	// The rewritten SQL should also use backtick-quoted temp name
+	if !strings.Contains(result, "SELECT * FROM `case`;") {
+		t.Errorf("expected backtick-quoted reference in rewritten SQL, got:\n%s", result)
 	}
 }
 


### PR DESCRIPTION
## Summary
- temp table名を常にバッククォートで囲むようにし、`case`等のBigQuery予約語と衝突する問題を修正
- `script/script.go`の`generateFixtureSQL()`と`rewriter/rewriter.go`の`Rewrite()`の両方で対応
- 予約語テーブル名のテストケースを追加

Closes #17

## Test plan
- [x] `go test ./...` 全パス確認
- [ ] `case`テーブルを含むfixtureで実際のBigQuery実行を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)