### PR TITLE
fix(ci): main pushでmacOSビルドキャッシュを事前作成

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,42 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-build-linux-amd64-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-linux-amd64-
       - name: Install clang
         run: |
           sudo apt-get update
           sudo apt-get install -y clang
       - run: go test ./...
+
+  # Build on macOS to warm the cache for release workflow
+  build-cache-macos:
+    runs-on: macos-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/Library/Caches/go-build
+          key: go-build-darwin-arm64-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-darwin-arm64-
+      - name: Build
+        env:
+          CGO_ENABLED: 1
+          CC: clang
+          CXX: clang++
+        run: go build ./cmd/bqtest/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-build-linux-amd64-${{ hashFiles('go.sum') }}
+          key: go-build-linux-amd64-${{ hashFiles('**/go.mod', '**/go.sum') }}
           restore-keys: go-build-linux-amd64-
       - name: Install clang
         run: |
@@ -48,7 +48,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/Library/Caches/go-build
-          key: go-build-darwin-arm64-${{ hashFiles('go.sum') }}
+          key: go-build-darwin-arm64-${{ hashFiles('**/go.mod', '**/go.sum') }}
           restore-keys: go-build-darwin-arm64-
       - name: Build
         env:


### PR DESCRIPTION
## Summary

GitHub Actions のキャッシュスコープ制限により、タグ push 間ではキャッシュを共有できない。
ただし default branch (main) のキャッシュはタグ push から参照可能。

CI に macOS ビルドジョブ (`build-cache-macos`) を追加し、main push 時にキャッシュを warm する。
`if: github.event_name == 'push'` で PR 時は実行しない（macOS runner のコスト節約）。

## Test plan

- [ ] マージ後の main push で macOS キャッシュが作成されることを確認
- [ ] 次のタグ push でキャッシュが restored されビルド時間が短縮されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)